### PR TITLE
feat: Add NASA ADS API key input field to preferences

### DIFF
--- a/locale/en-US/citation-counts.ftl
+++ b/locale/en-US/citation-counts.ftl
@@ -31,6 +31,7 @@ citationcounts-preferences-pane-autoretrieve-api =
     .label = { $api }
 citationcounts-preferences-pane-autoretrieve-api-none =
     .label = No
+citationcounts-preferences-pane-nasaads-api-key-label = NASA ADS API Key
 
 ## Misc
 citationcounts-internal-error = Internal error

--- a/preferences.xhtml
+++ b/preferences.xhtml
@@ -16,4 +16,16 @@
       <!-- Radiobuttons are dynamically created by the script -->
     </radiogroup>
   </groupbox>
+  <groupbox>
+    <label
+      ><html:h2
+        data-l10n-id="citationcounts-preferences-pane-nasaads-api-key-label"
+      ></html:h2
+    ></label>
+    <html:input
+      id="citationcounts-preference-pane-nasaads-api-key"
+      type="text"
+      preference="extensions.citationcounts.nasaadsApiKey"
+    />
+  </groupbox>
 </vbox>


### PR DESCRIPTION
This commit introduces an input field in the plugin's preferences to allow you to enter your NASA ADS API key.

The changes include:
- Modifying `preferences.xhtml` to add the text input field, linked to the `extensions.citationcounts.nasaadsApiKey` preference.
- Updating `locale/en-US/citation-counts.ftl` to include the localization for the new input field's label.

The plugin already had the underlying preference defined and the logic to use this key when making API requests to NASA ADS. This change provides the UI element for you to set this key.