### PR TITLE
feat: Add unit tests, integration tests, and CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,30 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main ] # Assuming 'main' is the default branch. If not, adjust.
+  pull_request:
+    branches: [ main ] # Assuming 'main' is the default branch. If not, adjust.
+
+jobs:
+  run-unit-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x] # Specify Node.js versions to test on
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4 # Use a recent stable version
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4 # Use a recent stable version
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/locale/en-US/citation-counts.ftl
+++ b/locale/en-US/citation-counts.ftl
@@ -14,6 +14,7 @@ citationcounts-progresswindow-error-no-doi = No DOI field exists on the item.
 citationcounts-progresswindow-error-no-arxiv = No arXiv id found on the item.
 citationcounts-progresswindow-error-no-doi-or-arxiv = No DOI / arXiv ID found on the item.
 citationcounts-progresswindow-error-bad-api-response = Problem accesing the { $api } API.
+citationcounts-progresswindow-error-nasaads-apikey = NASA ADS API Key error. Please check your key in preferences or visit the NASA ADS website for more information. It's also possible you've hit an API rate limit.
 citationcounts-progresswindow-error-no-citation-count = { $api } doesn't have a citation count for this item.
 
 ## For the "Tools" menu, where the "autoretrieve" preference can be set.
@@ -31,6 +32,7 @@ citationcounts-preferences-pane-autoretrieve-api =
     .label = { $api }
 citationcounts-preferences-pane-autoretrieve-api-none =
     .label = No
+citationcounts-preferences-pane-nasaads-api-key-label = NASA ADS API Key
 
 ## Misc
 citationcounts-internal-error = Internal error

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "zotero-citation-counts-manager",
   "version": "1.0.0",
   "scripts": {
-    "build": "web-ext build --source-dir=. --artifacts-dir=dist --overwrite-dest -n zoterocitationcountsmanager-$(date +%Y%m%d).xpi --ignore-files bin/* node_modules/* package.json package-lock.json README.md LICENSE .git/* .github/* .gitignore dist/*"
+    "build": "web-ext build --source-dir=. --artifacts-dir=dist --overwrite-dest -n zoterocitationcountsmanager-$(date +%Y%m%d).xpi --ignore-files bin/* node_modules/* package.json package-lock.json README.md LICENSE .git/* .github/* .gitignore dist/*",
+    "test:unit": "mocha test/unit/**/*.test.js"
   },
   "devDependencies": {
-    "web-ext": "^6.4.0"
+    "web-ext": "^6.4.0",
+    "mocha": "^10.2.0",
+    "chai": "^4.3.10",
+    "sinon": "^17.0.1"
   }
 }

--- a/preferences.xhtml
+++ b/preferences.xhtml
@@ -16,4 +16,16 @@
       <!-- Radiobuttons are dynamically created by the script -->
     </radiogroup>
   </groupbox>
+  <groupbox>
+    <label
+      ><html:h2
+        data-l10n-id="citationcounts-preferences-pane-nasaads-api-key-label"
+      ></html:h2
+    ></label>
+    <html:input
+      id="citationcounts-preference-pane-nasaads-api-key"
+      type="text"
+      preference="extensions.citationcounts.nasaadsApiKey"
+    />
+  </groupbox>
 </vbox>

--- a/test/integration/nasaads.integration.test.js
+++ b/test/integration/nasaads.integration.test.js
@@ -1,0 +1,229 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const fs = require('fs');
+const path = require('path');
+
+// Helper function from the subtask description
+function createMockItem(doi, extraContent = "", arxivId = null, url = null) {
+  const item = {
+    _DOI: doi,
+    _extra: extraContent,
+    _arxivId: arxivId,
+    _url: url,
+    getField: sinon.stub(),
+    setField: sinon.stub(),
+    saveTx: sinon.stub().resolves(),
+    isFeedItem: false,
+    // A simple way to identify items for debugging tests
+    id: doi || arxivId || `item-${Math.random().toString(36).substr(2, 9)}`,
+  };
+  item.getField.withArgs('DOI').returns(item._DOI);
+  item.getField.withArgs('extra').returns(item._extra);
+  item.getField.withArgs('url').returns(item._url); // For _getArxiv
+  // If your _getArxiv logic is more complex, adjust this stub or add more specific ones.
+  // For example, if it parses arXiv ID from the 'extra' field as a fallback:
+  // item.getField.withArgs('extra').returns(item._extra); 
+  return item;
+}
+
+
+describe('ZoteroCitationCounts - NASA ADS Integration Tests', function() {
+  let zccCode;
+  let mockZoteroPane;
+  let mockProgressWindowInstance;
+  let mockItemProgressInstance;
+  let mockGetSelectedItems;
+  let originalDateToISOString;
+
+  beforeEach(function() {
+    // Mock Zotero.ProgressWindow.ItemProgress first as it's a constructor used by Zotero.ProgressWindow
+    mockItemProgressInstance = {
+      setIcon: sinon.stub(),
+      setText: sinon.stub(),
+      setProgress: sinon.stub(),
+      setError: sinon.stub(),
+      // Mock any other methods that might be called on an ItemProgress instance
+    };
+    const MockItemProgressConstructor = sinon.stub().returns(mockItemProgressInstance);
+
+    // Mock Zotero.ProgressWindow
+    mockProgressWindowInstance = {
+      changeHeadline: sinon.stub(),
+      show: sinon.stub(),
+      ItemProgress: MockItemProgressConstructor, // Assign the mocked constructor
+      startCloseTimer: sinon.stub(),
+    };
+    const MockProgressWindowConstructor = sinon.stub().returns(mockProgressWindowInstance);
+
+    // Mock Zotero pane
+    mockGetSelectedItems = sinon.stub();
+    mockZoteroPane = {
+      getSelectedItems: mockGetSelectedItems,
+    };
+
+    // Mock global Zotero object
+    global.Zotero = {
+      Prefs: {
+        get: sinon.stub(),
+        set: sinon.stub(),
+      },
+      debug: sinon.stub(), // For ZoteroCitationCounts._log
+      ProgressWindow: MockProgressWindowConstructor,
+      getActiveZoteroPane: sinon.stub().returns(mockZoteroPane),
+      // Mock Localization (L10n)
+      // ZoteroCitationCounts.l10n is initialized with `new Localization(["citation-counts.ftl"]);`
+      // We need to mock the constructor and its methods if used, or mock the instance directly after script load.
+      Localization: sinon.stub().returnsThis(), // Make constructor return 'this'
+      // Then mock methods on 'this' or on the instance if it's assigned (e.g., Zotero.L10n.formatValue)
+      // For simplicity, we'll mock formatValue on ZoteroCitationCounts.l10n after script load.
+      
+      // other necessary Zotero mocks
+      hiDPI: false, // For ZoteroCitationCounts.icon
+    };
+    
+    // Mock global.fetch
+    sinon.stub(global, 'fetch');
+
+    // Mock Date.prototype.toISOString to control date strings
+    const constantDate = new Date('2023-01-01T12:00:00.000Z');
+    originalDateToISOString = Date.prototype.toISOString;
+    Date.prototype.toISOString = sinon.stub().returns(constantDate.toISOString());
+
+
+    // Load ZoteroCitationCounts script
+    if (!zccCode) {
+      zccCode = fs.readFileSync(path.join(__dirname, '../../src/zoterocitationcounts.js'), 'utf-8');
+    }
+    // Inject Zotero mock into the script's scope
+    new Function('Zotero', zccCode)(global.Zotero);
+    
+    // Now that ZoteroCitationCounts is loaded and has its l10n instance, mock its formatValue
+    if (global.ZoteroCitationCounts && global.ZoteroCitationCounts.l10n) {
+      global.ZoteroCitationCounts.l10n.formatValue = sinon.stub().resolvesArg(0);
+    } else {
+      // Fallback if l10n is not on ZoteroCitationCounts but on Zotero.L10n instance
+      global.Zotero.L10n = { // Assuming L10n might be used as Zotero.L10n
+          formatValue: sinon.stub().resolvesArg(0)
+      };
+    }
+    // The init function is called during script load. APIs should be populated.
+    // Ensure ZoteroCitationCounts.init has been called
+    if (global.ZoteroCitationCounts && !global.ZoteroCitationCounts._initialized) {
+        global.ZoteroCitationCounts.init({ id: 'test-id', version: 'test-version', rootURI: 'test-uri/'});
+    }
+
+
+  });
+
+  afterEach(function() {
+    sinon.restore(); // Restores all sinon stubs and mocks
+    if (global.fetch && global.fetch.restore) {
+        global.fetch.restore(); // Specifically restore fetch if it was stubbed
+    }
+    Date.prototype.toISOString = originalDateToISOString; // Restore original toISOString
+    delete global.Zotero;
+    delete global.ZoteroCitationCounts; // Clean up global scope
+  });
+
+  // Test Scenarios will go here
+  describe('NASA ADS Scenarios', function() {
+    let nasaAdsApiObject;
+    let mockItems;
+
+    beforeEach(function() {
+      // Find NASA ADS API object
+      nasaAdsApiObject = global.ZoteroCitationCounts.APIs.find(api => api.key === 'nasaads');
+      expect(nasaAdsApiObject, "NASA ADS API object not found").to.exist;
+    });
+
+    it('Scenario 1: Successful fetch and update for NASA ADS (DOI)', async function() {
+      const mockItem = createMockItem('10.1234/test.doi');
+      mockItems = [mockItem];
+      mockGetSelectedItems.returns(mockItems);
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.nasaadsApiKey', true).returns('TEST_KEY');
+      
+      global.fetch.resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves({ response: { docs: [{ citation_count: 42 }] } }),
+      });
+
+      await global.ZoteroCitationCounts.updateItems(mockItems, nasaAdsApiObject);
+      
+      expect(global.fetch.calledOnce).to.be.true;
+      const fetchCall = global.fetch.getCall(0);
+      expect(fetchCall.args[0]).to.include('https://api.adsabs.harvard.edu/v1/search/query');
+      expect(fetchCall.args[0]).to.include('q=doi:10.1234%2Ftest.doi'); // URI encoded
+      expect(fetchCall.args[0]).to.include('api_key=TEST_KEY');
+      
+      expect(mockItem.setField.calledOnceWith('extra', '42 citations (NASA ADS/DOI) [2023-01-01]\n')).to.be.true;
+      expect(mockItem.saveTx.calledOnce).to.be.true;
+      
+      expect(mockProgressWindowInstance.ItemProgress.calledOnce).to.be.true;
+      expect(mockItemProgressInstance.setIcon.calledWith(sinon.match(/tick/))).to.be.true; // Or specific icon path
+      expect(mockItemProgressInstance.setProgress.calledWith(100)).to.be.true;
+
+      // Verify l10n calls for progress window headlines
+      expect(global.ZoteroCitationCounts.l10n.formatValue.calledWith('citationcounts-progresswindow-headline', { api: 'NASA ADS' })).to.be.true;
+      expect(global.ZoteroCitationCounts.l10n.formatValue.calledWith('citationcounts-progresswindow-finished-headline', { api: 'NASA ADS' })).to.be.true;
+    });
+
+    it('Scenario 2: NASA ADS API key error (401)', async function() {
+      const mockItem = createMockItem('10.1234/another.doi');
+      mockItems = [mockItem];
+      mockGetSelectedItems.returns(mockItems);
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.nasaadsApiKey', true).returns('WRONG_KEY');
+
+      global.fetch.resolves({
+        ok: false,
+        status: 401,
+        url: 'https://api.adsabs.harvard.edu/v1/search/query?q=doi:10.1234%2Fanother.doi&fl=citation_count&api_key=WRONG_KEY',
+      });
+
+      await global.ZoteroCitationCounts.updateItems(mockItems, nasaAdsApiObject);
+
+      expect(global.fetch.calledOnce).to.be.true;
+      expect(mockItem.setField.called).to.be.false; // No citation update
+      expect(mockItem.saveTx.called).to.be.false;
+
+      expect(mockProgressWindowInstance.ItemProgress.calledOnce).to.be.true;
+      expect(mockItemProgressInstance.setError.calledOnce).to.be.true;
+      
+      // Check that l10n was called to format the specific error message for the ProgressWindow item
+      // The error message itself is added as a new ItemProgress, so we check the text of that new ItemProgress
+      // This means ItemProgress constructor should be called twice: once for the item, once for the error.
+      expect(mockProgressWindowInstance.ItemProgress.calledTwice).to.be.true; // Original item + error item
+      const errorItemProgressCall = mockProgressWindowInstance.ItemProgress.getCall(1); // Second call is for the error.
+      expect(global.ZoteroCitationCounts.l10n.formatValue.calledWith('citationcounts-progresswindow-error-nasaads-apikey', { api: 'NASA ADS' })).to.be.true;
+      // Check the text passed to the error ItemProgress constructor
+      expect(errorItemProgressCall.args[1]).to.equal('citationcounts-progresswindow-error-nasaads-apikey'); 
+    });
+
+    it('Scenario 3: No DOI for NASA ADS (when DOI is the only identifier)', async function() {
+      const mockItem = createMockItem(null); // No DOI
+      mockItems = [mockItem];
+      mockGetSelectedItems.returns(mockItems);
+      // For this test, let's assume NASA ADS is configured to only use DOI or DOI is tried first.
+      // The nasaAdsApiObject by default has useDoi: true, useArxiv: true.
+      // To force this scenario, we can either:
+      // 1. Temporarily modify nasaAdsApiObject.useArxiv = false (if the test setup allows deep copy or restoration)
+      // 2. Ensure the mockItem doesn't have an arXiv ID either.
+      // The current createMockItem creates it without arXiv unless specified.
+
+      await global.ZoteroCitationCounts.updateItems(mockItems, nasaAdsApiObject);
+
+      expect(global.fetch.called).to.be.false; // Fetch should not be called if DOI is missing and it's the primary/only ID
+      expect(mockItem.setField.called).to.be.false;
+      expect(mockItem.saveTx.called).to.be.false;
+
+      expect(mockProgressWindowInstance.ItemProgress.calledOnce).to.be.true; // For the item itself
+      expect(mockItemProgressInstance.setError.calledOnce).to.be.true;
+
+      // Check for the "no DOI" error message.
+      expect(mockProgressWindowInstance.ItemProgress.calledTwice).to.be.true; // Original item + error item
+      const errorItemProgressCall = mockProgressWindowInstance.ItemProgress.getCall(1);
+      expect(global.ZoteroCitationCounts.l10n.formatValue.calledWith('citationcounts-progresswindow-error-no-doi', { api: 'NASA ADS' })).to.be.true;
+      expect(errorItemProgressCall.args[1]).to.equal('citationcounts-progresswindow-error-no-doi');
+    });
+  });
+});

--- a/test/unit/zoterocitationcounts.test.js
+++ b/test/unit/zoterocitationcounts.test.js
@@ -1,0 +1,277 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const fs = require('fs');
+const path = require('path');
+
+describe('ZoteroCitationCounts', function() {
+  let mockZoteroPrefsGet;
+  let zccCode;
+
+  beforeEach(function() {
+    // Setup Zotero mock
+    mockZoteroPrefsGet = sinon.stub();
+    global.Zotero = {
+      Prefs: {
+        get: mockZoteroPrefsGet,
+        // Add set stub if any tests require setting preferences
+        set: sinon.stub() 
+      },
+      debug: sinon.stub(), // Mock for this._log
+      // ... other necessary Zotero mocks
+    };
+
+    // Mock fetch
+    sinon.stub(global, 'fetch');
+
+    // Read the script content once
+    if (!zccCode) {
+      zccCode = fs.readFileSync(path.join(__dirname, '../../src/zoterocitationcounts.js'), 'utf-8');
+    }
+    
+    // Execute the script content, making ZoteroCitationCounts available globally
+    // and injecting the mocked Zotero object.
+    // Using new Function to avoid direct eval and to pass Zotero as an argument.
+    new Function('Zotero', zccCode)(global.Zotero);
+    
+    // Ensure that ZoteroCitationCounts.getPref is bound to the Zotero.Prefs.get mock for these tests
+    // This is necessary because the original script uses 'this.getPref' internally for _nasaadsUrl
+    // and 'this' inside _nasaadsUrl refers to ZoteroCitationCounts.
+    // We need to ensure that ZoteroCitationCounts.getPref calls our stubbed Zotero.Prefs.get.
+    // The ZoteroCitationCounts object is defined as an object literal, and its methods
+    // like getPref are defined within that literal. When these methods are called,
+    // 'this' correctly refers to ZoteroCitationCounts.
+    // The 'getPref' method in ZoteroCitationCounts itself calls Zotero.Prefs.get,
+    // which we have stubbed. So, direct assignment as below is not strictly needed
+    // if the script structure ensures 'this' is ZoteroCitationCounts.
+    // However, explicitly binding or ensuring the methods use the mocked global.Zotero
+    // can be a good safeguard.
+    // In this case, ZoteroCitationCounts.getPref will use global.Zotero.Prefs.get due to lexical scoping
+    // or the way 'this' is resolved in the original script when it refers to Zotero.Prefs.get.
+    // The new Function approach should make global.Zotero available to the script.
+  });
+
+  afterEach(function() {
+    sinon.restore();
+    if (global.fetch && global.fetch.restore) { // Ensure fetch was stubbed before trying to restore
+        global.fetch.restore();
+    }
+    delete global.Zotero;
+    delete global.ZoteroCitationCounts; // Clean up the global scope
+  });
+
+  describe('_nasaadsUrl', function() {
+    it('should construct the correct URL with API key for DOI', function() {
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.nasaadsApiKey', true).returns('TEST_API_KEY');
+      
+      const id = '10.1000/xyz123';
+      const type = 'doi';
+      // Note: _nasaadsUrl uses this.getPref internally. We must ensure this.getPref uses the stubbed Zotero.Prefs.get.
+      // The ZoteroCitationCounts object is directly available in the global scope after the new Function execution.
+      const actualUrl = global.ZoteroCitationCounts._nasaadsUrl(id, type);
+      const expectedUrl = `https://api.adsabs.harvard.edu/v1/search/query?q=doi:${id}&fl=citation_count&api_key=TEST_API_KEY`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should construct the correct URL with API key for arXiv', function() {
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.nasaadsApiKey', true).returns('TEST_API_KEY_ARXIV');
+      
+      const id = '2303.12345';
+      const type = 'arxiv';
+      const actualUrl = global.ZoteroCitationCounts._nasaadsUrl(id, type);
+      const expectedUrl = `https://api.adsabs.harvard.edu/v1/search/query?q=arxiv:${id}&fl=citation_count&api_key=TEST_API_KEY_ARXIV`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+
+    it('should use an empty string if API key is not set', function() {
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.nasaadsApiKey', true).returns('');
+      
+      const id = '10.1000/abc789';
+      const type = 'doi';
+      const actualUrl = global.ZoteroCitationCounts._nasaadsUrl(id, type);
+      const expectedUrl = `https://api.adsabs.harvard.edu/v1/search/query?q=doi:${id}&fl=citation_count&api_key=`;
+      expect(actualUrl).to.equal(expectedUrl);
+    });
+  });
+  
+  describe('getPref', function() {
+    it('should call Zotero.Prefs.get with the correct preference key', function() {
+      // The ZoteroCitationCounts object is globally available.
+      global.ZoteroCitationCounts.getPref('myTestPref');
+      expect(global.Zotero.Prefs.get.calledOnceWith('extensions.citationcounts.myTestPref', true)).to.be.true;
+    });
+
+    it('should return the value from Zotero.Prefs.get', function() {
+      global.Zotero.Prefs.get.withArgs('extensions.citationcounts.anotherPref', true).returns('expectedValue');
+      const val = global.ZoteroCitationCounts.getPref('anotherPref');
+      expect(val).to.equal('expectedValue');
+    });
+  });
+
+  describe('_sendRequest', function() {
+    const nasaAdsUrl = 'https://api.adsabs.harvard.edu/v1/search/query?q=doi:anything&api_key=SOMEKEY';
+    const otherApiUrl = 'https://api.anotherexample.com/data';
+    let mockCallback;
+
+    beforeEach(function() {
+      mockCallback = sinon.stub();
+    });
+
+    it('should throw nasaads-apikey error for NASA ADS 401 response', async function() {
+      global.fetch.resolves({
+        ok: false,
+        status: 401,
+        url: nasaAdsUrl 
+      });
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(nasaAdsUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-nasaads-apikey');
+      expect(global.Zotero.debug.calledWith(sinon.match(/NASA ADS API key error/))).to.be.true;
+    });
+
+    it('should throw nasaads-apikey error for NASA ADS 403 response', async function() {
+      global.fetch.resolves({
+        ok: false,
+        status: 403,
+        url: nasaAdsUrl
+      });
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(nasaAdsUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-nasaads-apikey');
+      expect(global.Zotero.debug.calledWith(sinon.match(/NASA ADS API key error/))).to.be.true;
+    });
+
+    it('should throw bad-api-response error for other NASA ADS errors (e.g., 500)', async function() {
+      global.fetch.resolves({
+        ok: false,
+        status: 500,
+        url: nasaAdsUrl
+      });
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(nasaAdsUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-bad-api-response');
+      expect(global.Zotero.debug.calledWith(sinon.match(/Bad API response for/))).to.be.true;
+    });
+
+    it('should throw bad-api-response error for non-NASA ADS API errors (e.g., 404)', async function() {
+      global.fetch.resolves({
+        ok: false,
+        status: 404,
+        url: otherApiUrl
+      });
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-bad-api-response');
+      expect(global.Zotero.debug.calledWith(sinon.match(/Bad API response for/))).to.be.true;
+    });
+
+    it('should throw bad-api-response error for network failures', async function() {
+      global.fetch.rejects(new Error('Network failure'));
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-bad-api-response');
+      expect(global.Zotero.debug.calledWith(sinon.match(/Network error fetching/))).to.be.true;
+    });
+
+    it('should return count for successful response and valid count', async function() {
+      const mockResponseData = { some_count_field: 123 };
+      global.fetch.resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves(mockResponseData)
+      });
+      mockCallback.returns(mockResponseData.some_count_field);
+
+      const count = await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      expect(count).to.equal(123);
+      expect(mockCallback.calledWith(mockResponseData)).to.be.true;
+    });
+
+    it('should throw no-citation-count error for successful response but invalid count (string)', async function() {
+      const mockResponseData = { some_count_field: "not-a-number" };
+      global.fetch.resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves(mockResponseData)
+      });
+      mockCallback.returns(mockResponseData.some_count_field);
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-no-citation-count');
+      expect(global.Zotero.debug.calledWith(sinon.match(/Error processing API response/))).to.be.true;
+    });
+    
+    it('should throw no-citation-count error for successful response but invalid count (negative)', async function() {
+      const mockResponseData = { some_count_field: -5 };
+      global.fetch.resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves(mockResponseData)
+      });
+      mockCallback.returns(mockResponseData.some_count_field);
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-no-citation-count');
+    });
+
+
+    it('should throw no-citation-count error for successful response but malformed JSON', async function() {
+      global.fetch.resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().rejects(new Error('JSON.parse: unexpected character at line 1 column 1 of the JSON data'))
+      });
+
+      let actualError = null;
+      try {
+        await global.ZoteroCitationCounts._sendRequest(otherApiUrl, mockCallback);
+      } catch (e) {
+        actualError = e;
+      }
+      expect(actualError).to.be.an('Error');
+      expect(actualError.message).to.equal('citationcounts-progresswindow-error-no-citation-count');
+      expect(global.Zotero.debug.calledWith(sinon.match(/Error processing API response/))).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a comprehensive testing suite and CI automation:

1.  **Unit Tests:**
    - Adds Mocha, Chai, and Sinon for unit testing.
    - Includes unit tests for `src/zoterocitationcounts.js`, covering:
        - `_nasaadsUrl` URL construction with API key.
        - `getPref` for preference retrieval. - `_sendRequest` for various API response scenarios (success, NASA ADS specific errors, general errors, network errors).
    - Mocks the Zotero environment and `fetch` for isolated testing.

2.  **Integration Tests:**
    - Adds integration tests for the NASA ADS citation retrieval flow using `updateItems`.
    - Covers successful updates, API key errors, and missing identifier scenarios.
    - Involves detailed mocking of the Zotero environment (items, ProgressWindow, preferences, l10n).

3.  **GitHub Workflow (CI):**
    - Sets up a GitHub Actions workflow in `.github/workflows/unit-tests.yml`.
    - Automatically runs unit tests on pushes and pull requests to the `main` branch using Node.js 18.x.

These changes significantly improve the robustness and maintainability of the plugin by providing automated checks for key functionalities.