### PR TITLE
Fix success notification bug - change setImage back to setIcon

### DIFF
--- a/src/zoterocitationcounts.js
+++ b/src/zoterocitationcounts.js
@@ -390,7 +390,7 @@ ZoteroCitationCounts = {
         this._setCitationCount(item, source, count);
         this._log(`[Info] _updateItem: _setCitationCount finished for item '${item.getField('title') || item.id}'`);
 
-        pwItem.setImage(this.icon("tick")); // Changed setIcon to setImage
+        pwItem.setIcon(this.icon("tick"));
         pwItem.setProgress(100);
       } catch (error) {
         this._log(`[Error] _updateItem: Error processing item '${item.getField('title') || item.id}': ${error.message}${error.stack ? '\nStack: ' + error.stack : ''}`);

--- a/test/integration/semanticscholar.integration.test.js
+++ b/test/integration/semanticscholar.integration.test.js
@@ -183,7 +183,7 @@ describe("Semantic Scholar Integration Tests", () => {
       const pwInstance = mockZotero.ProgressWindow.returnValues[0];
       sinon.assert.calledOnce(pwInstance.ItemProgress); 
       const itemProgressInstance = pwInstance.ItemProgress.returnValues[0];
-      sinon.assert.calledWith(itemProgressInstance.setImage, global.ZoteroCitationCounts.icon("tick"));
+      sinon.assert.calledWith(itemProgressInstance.setIcon, global.ZoteroCitationCounts.icon("tick"));
       sinon.assert.calledWith(itemProgressInstance.setProgress, 100);
     });
 


### PR DESCRIPTION
Citation count retrieval was successful but showing failure notifications due to using setImage() instead of setIcon() for the success tick icon.

Fixed by:
- Changed pwItem.setImage(this.icon('tick')) to pwItem.setIcon(this.icon('tick'))
- Updated Semantic Scholar test to expect setIcon instead of setImage

Fixes #30

Generated with [Claude Code](https://claude.ai/code)